### PR TITLE
Add TonyT908 to builders group

### DIFF
--- a/data/delegates.json
+++ b/data/delegates.json
@@ -343,5 +343,22 @@
     "poolMember": false, 
     "required": false, 
     "featured": false 
+  },
+  {
+    "delegateName": "tonyt908",
+    "delegateAddress": "15297866638783057016L",
+    "proposal": "https://www.tonyt908.com",
+    "githubUsername": "MorinelloA",
+    "poolPercentage": {
+      "P": "50",
+      "D": "10",
+      "O": "40"
+    },
+    "affiliation": "Freelance",
+    "liskChat": "TonyT908",
+    "pool": "",
+    "poolMember": false,
+    "required": false,
+    "featured": false
   }
 ]


### PR DESCRIPTION
I am very thrilled to finally apply to be an official member of Lisk Builders. My entire delegate proposal, along with my list of contributions to Lisk, can be found at [www.tonyt908.com](url). If you have any questions, please let me know.