### PR TITLE
votemanager: replace Elite in max payouts

### DIFF
--- a/scripts/votemanager/VoteManagerControls.tsx
+++ b/scripts/votemanager/VoteManagerControls.tsx
@@ -71,7 +71,7 @@ export default class VoteManagerControls extends Component<any, any> {
   }
 
   setSelectedToMaximum() {
-    const payoutmax = _.uniq([...groups.gdt.data, ...groups.elite.data, ...groups.shw.data, 'thepool', 'liskpool_com_01', 'shinekami', 'vipertkd', 'vrlc92', 'communitypool', 'devasive', 'samuray', 'stellardynamic']).filter(e => ['4fryn', 'liskascend'].indexOf(e) === -1);
+    const payoutmax = _.uniq([...groups.gdt.data, ...groups.ascend.data, ...groups.shw.data,, ...groups.builders.data, ...groups.lig.data, ...groups.dutchpool.data, 'thepool', 'liskpool_com_01', 'liskpool.top', 'shinekami', 'vipertkd', 'vrlc92', 'communitypool', 'devasive', 'samuray', 'stellardynamic']);
     this.closeModal('wizard');
     this.props.store.setSelectedDelegates(payoutmax);
   }

--- a/scripts/votemanager/VoteManagerControls.tsx
+++ b/scripts/votemanager/VoteManagerControls.tsx
@@ -71,7 +71,7 @@ export default class VoteManagerControls extends Component<any, any> {
   }
 
   setSelectedToMaximum() {
-    const payoutmax = _.uniq([...groups.gdt.data, ...groups.ascend.data, ...groups.shw.data,, ...groups.builders.data, ...groups.lig.data, ...groups.dutchpool.data, 'thepool', 'liskpool_com_01', 'liskpool.top', 'shinekami', 'vipertkd', 'vrlc92', 'communitypool', 'devasive', 'samuray', 'stellardynamic']);
+    const payoutmax = _.uniq([...groups.gdt.data, ...groups.ascend.data, ...groups.shw.data, ...groups.builders.data, ...groups.lig.data, ...groups.dutchpool.data, 'thepool', 'liskpool_com_01', 'liskpool.top', 'shinekami', 'vipertkd', 'vrlc92', 'communitypool', 'devasive', 'samuray', 'stellardynamic']);
     this.closeModal('wizard');
     this.props.store.setSelectedDelegates(payoutmax);
   }


### PR DESCRIPTION
- sherwood payouts are higher if you unvote elite
- restored liskpool.top independent active delegate
- added ascend, dutch, lig, and builders